### PR TITLE
Fix mother zombie choosing

### DIFF
--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -26,21 +26,24 @@ function Infect_PickMotherZombies()
     local function PickMotherZombies()
         local tPlayerTableShuffled = table.shuffle(tPlayerTable)
 
-        for idx = 1,#tPlayerTableShuffled do
+        for idx = 1, #tPlayerTableShuffled do
             local hPlayer = tPlayerTableShuffled[idx]
             local tPlayerScope = hPlayer:GetOrCreatePrivateScriptScope()
 
             local iSkipChance = tPlayerScope.MZSpawn_SkipChance or 0
             -- if MZSpawn_SkipChance is not initialized, then the if below is guaranteed to not pass
             -- Roll for player's chance to skip being picked as MZ
-            if math.random(1,100) <= iSkipChance then
+            if math.random(1, 100) <= iSkipChance then
                 -- player succeeded the roll and avoided being picked as MZ,
                 -- reduce the value of his SkipChance script scope variable (just for good measure)
                 tPlayerScope.MZSpawn_SkipChance = tPlayerScope.MZSpawn_SkipChance - 20
             else
                 -- player failed the roll, pick him as MZ and initialize/refresh value of the SkipChance variable in his script scope
                 tPlayerScope.MZSpawn_SkipChance = 100
-                table.insert(tMotherZombies,hPlayer)
+                table.insert(tMotherZombies, hPlayer)
+                
+                -- remove player from players table so they can't be chosen again
+                table.RemoveValue(tPlayerTable, hPlayer)
             end
 
             if #tMotherZombies == iMotherZombieCount then return end

--- a/scripts/vscripts/util/functions.lua
+++ b/scripts/vscripts/util/functions.lua
@@ -14,3 +14,13 @@ function table.shuffle(tbl)
     end
     return tbl
 end
+
+-- removes all instances of a given value
+-- from a given table
+function table.RemoveValue(tbl, value)
+    for i = #tbl, 1, -1 do
+        if tbl[i] == value then
+            table.remove(tbl, i)
+        end
+    end
+end


### PR DESCRIPTION
Removes a player's handle from the potential players that could be chosen once they have been chosen this round.