### PR TITLE
Fix infection timer starting during freezetime

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -28,7 +28,6 @@ function OnRoundStart(event)
     Convars:SetInt('mp_ignore_round_win_conditions',1)
     ScriptPrintMessageChatAll("The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.")
     SetAllHuman()
-    Infect_OnRoundStart()
     DoEntFireByInstanceHandle(world,"RunScriptCode","Convars:SetInt('mp_respawn_on_death_t',0)",test_repeatkiller_time,nil,nil)
     DoEntFireByInstanceHandle(world,"RunScriptCode","Convars:SetInt('mp_ignore_round_win_conditions',0)",test_repeatkiller_time,nil,nil)
     DoEntFireByInstanceHandle(world,"RunScriptCode","Say(nil,'RepeatKiller activated',false)",test_repeatkiller_time,nil,nil)
@@ -77,7 +76,8 @@ end
 tListenerIds = {
     ListenToGameEvent("player_hurt", OnPlayerHurt, nil),
     ListenToGameEvent("player_death", OnPlayerDeath, nil),
+    ListenToGameEvent("round_start", OnRoundStart, nil),
     ListenToGameEvent("hegrenade_detonate", Knockback_OnGrenadeDetonate, nil),
     ListenToGameEvent("molotov_detonate", Knockback_OnMolotovDetonate, nil),
-    ListenToGameEvent("round_start", OnRoundStart, nil)
+    ListenToGameEvent("round_freeze_end", Infect_OnRoundFreezeEnd, nil)
 }

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -70,8 +70,7 @@ function Infect_PickMotherZombies()
     print("Player count: " .. iPlayerCount .. ", Mother Zombies Spawned: " .. iMotherZombieCount)
 end
 
--- hook this to OnRoundStart in main script
-function Infect_OnRoundStart()
+function Infect_OnRoundFreezeEnd()
     local iMZSpawntimeMinimum = (Convars:GetInt("zr_infect_spawn_time_min") or iInfectSpawntimeMin)
     local iMZSpawntimeMaximum = (Convars:GetInt("zr_infect_spawn_time_max") or iInfectSpawntimeMax)
     local iMZSpawntime = math.random(iMZSpawntimeMinimum,iMZSpawntimeMaximum)


### PR DESCRIPTION
This fixes different `mp_freezetime` values changing how long humans have to get out of spawn before infection, also a Zombie:Reloaded parity change.