### PR TITLE
Remove grenades if sv_infinite_ammo > 0

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -4,6 +4,7 @@ require "ZombieReborn.util.const"
 require "ZombieReborn.util.functions"
 require "ZombieReborn.util.timers"
 
+require "ZombieReborn/GrenadeRemover"
 require "ZombieReborn.Convars"
 require "ZombieReborn.Infect"
 require "ZombieReborn.Knockback"
@@ -98,5 +99,6 @@ tListenerIds = {
     ListenToGameEvent("round_start", OnRoundStart, nil),
     ListenToGameEvent("hegrenade_detonate", Knockback_OnGrenadeDetonate, nil),
     ListenToGameEvent("molotov_detonate", Knockback_OnMolotovDetonate, nil),
-    ListenToGameEvent("round_freeze_end", Infect_OnRoundFreezeEnd, nil)
+    ListenToGameEvent("round_freeze_end", Infect_OnRoundFreezeEnd, nil),
+    ListenToGameEvent("weapon_fire", RemoveGrenade, nil),
 }

--- a/scripts/vscripts/ZombieReborn/GrenadeRemover.lua
+++ b/scripts/vscripts/ZombieReborn/GrenadeRemover.lua
@@ -1,0 +1,45 @@
+--[[
+weapon_reload event does not fire so we can't replenish ammo when players reloaded
+Workaround is using sv_infinite_ammo 2 but that introduces infinite grenades
+
+This function removes players grenade if he threw one
+Removes all grenades even if player had 2 HE grenades
+--]]
+
+function RemoveGrenade(event)
+    -- Don't do anything if infinite ammo is off
+    if Convars:GetInt("sv_infinite_ammo") == 0 then return end
+
+    local hPlayer = EHandleToHScript(event.userid_pawn)
+
+    -- Support all grenades for now
+    local tGrenades = {"weapon_hegrenade", "weapon_molotov", "weapon_incgrenade", "weapon_flashbang", "weapon_smokegrenade", "weapon_decoy"}    
+
+    -- For the love of god aint no way lua is this shit
+    for key, value in ipairs(tGrenades) do
+        if event.weapon == value then
+            local tPlayerWeapons = hPlayer:GetEquippedWeapons()
+
+            for key, value in ipairs(tPlayerWeapons) do
+                local hWeapon = value
+
+                for key, value in ipairs(tGrenades) do
+                    if value == hWeapon:GetClassname() then
+                        -- Create only one clientcommand to avoid string table leak
+                        if Entities:FindByClassname(nil, "point_clientcommand") == nil then
+                            local hClientCMD = SpawnEntityFromTableSynchronous("point_clientcommand", nil)
+                        end
+                        -- Reassign the variable because lua is awful
+                        hClientCMD = Entities:FindByClassname(nil, "point_clientcommand")
+
+                        -- Remove the grenade (delay it else bug happens)
+                        DoEntFireByInstanceHandle(hWeapon, "Kill", "", 0.10, nil, nil)
+
+                        -- Ugly hack to switch guns because killed grenade leaves you with nothing equipped
+                        DoEntFireByInstanceHandle(hClientCMD, "Command", "lastinv", 0.15, hPlayer, hPlayer)
+                    end
+                end
+            end
+        end
+    end
+end

--- a/scripts/vscripts/ZombieReborn/GrenadeRemover.lua
+++ b/scripts/vscripts/ZombieReborn/GrenadeRemover.lua
@@ -25,12 +25,11 @@ function RemoveGrenade(event)
 
                 for key, value in ipairs(tGrenades) do
                     if value == hWeapon:GetClassname() then
-                        -- Create only one clientcommand to avoid string table leak
-                        if Entities:FindByClassname(nil, "point_clientcommand") == nil then
-                            local hClientCMD = SpawnEntityFromTableSynchronous("point_clientcommand", nil)
+                        local hClientCMD = Entities:FindByClassname(nil, "point_clientcommand")
+
+                        if not hClientCMD then
+                            hClientCMD = SpawnEntityFromTableSynchronous("point_clientcommand", nil)
                         end
-                        -- Reassign the variable because lua is awful
-                        hClientCMD = Entities:FindByClassname(nil, "point_clientcommand")
 
                         -- Remove the grenade (delay it else bug happens)
                         DoEntFireByInstanceHandle(hWeapon, "Kill", "", 0.10, nil, nil)


### PR DESCRIPTION
Currently best bet is to use sv_infinite_ammo 2 and just remove grenades from players after they've been thrown.