### PR TITLE
Start making full use of convars now that they're fixed

### DIFF
--- a/scripts/vscripts/ZombieReborn/Convars.lua
+++ b/scripts/vscripts/ZombieReborn/Convars.lua
@@ -1,37 +1,9 @@
--- Registering convars seems to be broken at the moment, so we currently expose the default values as variables as well
+-- Infect
+Convars:RegisterConvar("zr_infect_spawn_type", "1", "Type of Mother Zombies Spawn [0 = MZ spawn where they stand, 1 = MZ get teleported back to spawn on being picked]", FCVAR_RELEASE)
+Convars:RegisterConvar("zr_infect_spawn_time_min", "15", "Minimum time in which Mother Zombies should be picked, after round start", FCVAR_RELEASE)
+Convars:RegisterConvar("zr_infect_spawn_time_max", "15", "Maximum time in which Mother Zombies should be picked, after round start", FCVAR_RELEASE)
+Convars:RegisterConvar("zr_infect_spawn_mz_ratio", "7", "Ratio of all Players to Mother Zombies to be spawned at round start", FCVAR_RELEASE)
+Convars:RegisterConvar("zr_infect_spawn_mz_min_count", "2", "Minimum amount of Mother Zombies to be spawned at round start", FCVAR_RELEASE)
 
-local Config = {
-    Infect = {
-        SpawnType = 1,
-        SpawnTimeMin = 15,
-        SpawnTimeMax = 15,
-        SpawnMZRatio = 7,
-        SpawnMZMinCount = 2
-    },
-    Knockback = {
-        Scale = 5
-    }
-}
-
-Convars:RegisterConvar("zr_infect_spawn_type", tostring(Config.Infect.SpawnType), "Type of Mother Zombies Spawn [0 = MZ spawn where they stand, 1 = MZ get teleported back to spawn on being picked]", 0)
-Convars:RegisterConvar("zr_infect_spawn_time_min", tostring(Config.Infect.SpawnTimeMin), "Minimum time in which Mother Zombies should be picked, after round start", 0)
-Convars:RegisterConvar("zr_infect_spawn_time_max", tostring(Config.Infect.SpawnTimeMax), "Maximum time in which Mother Zombies should be picked, after round start", 0)
-Convars:RegisterConvar("zr_infect_spawn_mz_ratio", tostring(Config.Infect.SpawnMZRatio), "Ratio of all Players to Mother Zombies to be spawned at round start", 0)
-Convars:RegisterConvar("zr_infect_spawn_mz_min_count", tostring(Config.Infect.SpawnMZMinCount), "Minimum amount of Mother Zombies to be spawned at round start", 0)
-
-Convars:RegisterConvar("zr_knockback_scale", tostring(Config.Knockback.Scale), "Knockback damage multiplier", 0)
-
--- Create a table to store cvars
-CVARS = {}
-
-CVARS.Infect = {
-    SpawnType = Convars:GetInt("zr_infect_spawn_type") or Config.Infect.SpawnType,
-    SpawnTimeMin = Convars:GetInt("zr_infect_spawn_time_min") or Config.Infect.SpawnTimeMin,
-    SpawnTimeMax = Convars:GetInt("zr_infect_spawn_time_max") or Config.Infect.SpawnTimeMax,
-    SpawnMZRatio = Convars:GetInt("zr_infect_spawn_mz_ratio") or Config.Infect.SpawnMZRatio,
-    SpawnMZMinCount = Convars:GetInt("zr_infect_spawn_mz_min_count") or Config.Infect.SpawnMZMinCount
-}
-
-CVARS.Knockback = {
-    Scale = Convars:GetInt("zr_knockback_scale") or Config.Knockback.Scale
-}
+-- Knockback
+Convars:RegisterConvar("zr_knockback_scale", "5", "Knockback damage multiplier", FCVAR_RELEASE)

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -19,9 +19,9 @@ function Infect(hInflictor, hInfected, bKeepPosition)
 end
 
 function Infect_PickMotherZombies()
-    local iMZRatio = CVARS.Infect.SpawnMZRatio
-    local iMZMinimumCount = CVARS.Infect.SpawnMZMinCount
-    local bSpawnType = (CVARS.Infect.SpawnType == 0)
+    local iMZRatio = Convars:GetInt("zr_infect_spawn_mz_ratio")
+    local iMZMinimumCount = Convars:GetInt("zr_infect_spawn_mz_min_count")
+    local bSpawnType = (Convars:GetInt("zr_infect_spawn_type") == 0)
     local tPlayerTable = Entities:FindAllByClassname("player")
     local iPlayerCount = #tPlayerTable--also counting spectators
     local iMotherZombieCount = math.floor(iPlayerCount / iMZRatio)
@@ -90,8 +90,8 @@ function Infect_PickMotherZombies()
 end
 
 function Infect_OnRoundFreezeEnd()
-    local iMZSpawntimeMinimum = CVARS.Infect.SpawnTimeMin
-    local iMZSpawntimeMaximum = CVARS.Infect.SpawnTimeMax
+    local iMZSpawntimeMinimum = Convars:GetInt("zr_infect_spawn_time_min")
+    local iMZSpawntimeMaximum = Convars:GetInt("zr_infect_spawn_time_max")
     local iMZSpawntime = math.random(iMZSpawntimeMinimum,iMZSpawntimeMaximum)
 
     -- reduce mother zombie spawn skip chance for players who have that variable in their script scope

--- a/scripts/vscripts/ZombieReborn/Knockback.lua
+++ b/scripts/vscripts/ZombieReborn/Knockback.lua
@@ -1,7 +1,7 @@
 tWeaponConfigs = LoadKeyValues("cfg\\zr\\weapons.cfg")
 
 function Knockback_Apply(hHuman, hZombie, iDamage, sWeapon)
-    local iScale = CVARS.Knockback.Scale
+    local iScale = Convars:GetInt("zr_knockback_scale")
 
     if tWeaponConfigs and tWeaponConfigs[sWeapon] and tWeaponConfigs[sWeapon].knockback then
         iScale = iScale * tWeaponConfigs[sWeapon].knockback

--- a/scripts/vscripts/ZombieReborn/util/const.lua
+++ b/scripts/vscripts/ZombieReborn/util/const.lua
@@ -2,3 +2,6 @@ CS_TEAM_NONE = 0
 CS_TEAM_SPECTATOR = 1
 CS_TEAM_T = 2
 CS_TEAM_CT = 3
+
+-- Allows our cvars to autocomplete in console
+FCVAR_RELEASE = bit.lshift(1, 19)


### PR DESCRIPTION
Now that convars are working properly, we don't need to store their default values for use in a Config table. We're also removing the CVARS table, because even though it's a nicer design than calling the cvar by name everywhere, it caches the initial return and prevents any future cvar changes from actually taking effect.

We also add the `FCVAR_RELEASE` flag to our convars, since it allows them to autocomplete in console.
![image](https://user-images.githubusercontent.com/6075172/229306265-aa7f6fb9-4c13-4c24-89cb-091e9777bce5.png)