### PR TITLE
Fix point_clientcommand init

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -27,11 +27,10 @@ function OnRoundStart(event)
     ZR_ZOMBIE_SPAWNED = false
 
     -- Make sure point_clientcommand exists
-    if Entities:FindByClassname(nil, "point_clientcommand") == nil
-        then
-            clientcmd = SpawnEntityFromTableSynchronous("point_clientcommand", {targetname="vscript_clientcommand"})
-        else
-            clientcmd = Entities:FindByClassname(nil, "point_clientcommand")
+    clientcmd = Entities:FindByClassname(nil, "point_clientcommand")
+	
+    if clientcmd == nil then
+        clientcmd = SpawnEntityFromTableSynchronous("point_clientcommand", {targetname="vscript_clientcommand"})
     end
     
     -- Create timer to replenish ammo

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -26,10 +26,14 @@ end
 function OnRoundStart(event)
     ZR_ZOMBIE_SPAWNED = false
 
-    -- Create clientcommand for weapon swapping
-    if Entities:FindByClassname(nil, "point_clientcommand") == nil then
-        clientcmd = SpawnEntityFromTableSynchronous("point_clientcommand", {targetname="vscript_clientcommand"})
+    -- Make sure point_clientcommand exists
+    if Entities:FindByClassname(nil, "point_clientcommand") == nil
+        then
+            clientcmd = SpawnEntityFromTableSynchronous("point_clientcommand", {targetname="vscript_clientcommand"})
+        else
+            clientcmd = Entities:FindByClassname(nil, "point_clientcommand")
     end
+    
     -- Create timer to replenish ammo
     if not Timers:TimerExists(zr_ammo_timer) then
         Timers:CreateTimer("zr_ammo_timer", {


### PR DESCRIPTION
It would cause errors if map created point_clientcommand because the check wouldn't handle if one already exists to assign the variable