### PR TITLE
Add more health for zombies

### DIFF
--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -13,6 +13,8 @@ function Infect(hInflictor, hInfected, bKeepPosition)
     end
 
     hInfected:SetTeam(CS_TEAM_T)
+    ApplyMaxHealthOnInfection(hInfected)
+
     if bKeepPosition == false then return end
     hInfected:SetOrigin(vecOrigin)
     hInfected:SetAngles(vecAngles.x, vecAngles.y, vecAngles.z)
@@ -80,7 +82,9 @@ function Infect_PickMotherZombies()
     -- can iterate over the tMotherZombies here to print players who got picked as MZ to console
     -- (in the future, when we surely get access to player's steamid and nickname from lua)
 
+    local iHealthPerZombie = iPlayerCount * 350 / iMotherZombieCount
     for index,player in pairs(tMotherZombies) do
+        SetZombieHealthRecord(player, iHealthPerZombie)
         Infect(nil, player, bSpawnType)
     end
     print("Player count: " .. iPlayerCount .. ", Mother Zombies Spawned: " .. iMotherZombieCount)

--- a/scripts/vscripts/ZombieReborn/ZombieHealth.lua
+++ b/scripts/vscripts/ZombieReborn/ZombieHealth.lua
@@ -1,0 +1,51 @@
+g_PlayerHealthRecord = g_PlayerHealthRecord or {}
+g_PlayerNextRecoveryTime = g_PlayerNextRecoveryTime or {}
+
+local ZOMBIE_HEALTH_RECOVER_INTERVAL = 1
+local ZOMBIE_HEALTH_DEFAULT_VALUE = 1400
+
+function SetupZombieHealth()
+    g_PlayerHealthRecord = {}
+
+    Timers:CreateTimer("ZombieHealth_Timer",{
+        callback = function()
+            xpcall(ApplyZombieHealthRecoveryAll, PrintLuaError)
+            return 0.1
+        end
+    })
+end
+
+function SetZombieHealthRecord(hPlayer, iValue)
+    g_PlayerHealthRecord[hPlayer:GetEntityIndex()] = iValue
+end
+
+function SetZombieHealthRecordInfection(hAttacker, hVictim)
+    local iCustomHealth = math.max(hAttacker:GetHealth() / 2, ZOMBIE_HEALTH_DEFAULT_VALUE)
+    SetZombieHealthRecord(hVictim, iCustomHealth)
+end
+
+function ApplyMaxHealthOnInfection(hPlayer)
+    local CustomHealth = g_PlayerHealthRecord[hPlayer:GetEntityIndex()] or math.max(hPlayer:GetMaxHealth(), ZOMBIE_HEALTH_DEFAULT_VALUE)
+    hPlayer:SetHealth(CustomHealth)
+    hPlayer:SetMaxHealth(CustomHealth)
+end
+
+function PauseZombieHealthRecovery(hPlayer)
+    g_PlayerNextRecoveryTime[hPlayer:GetEntityIndex()] = Time() + 1
+end
+
+function ApplyZombieHealthRecoveryAll()
+    local tPlayerTable = Entities:FindAllByClassname("player")
+    for _, hPlayer in ipairs(tPlayerTable) do
+        ApplyZombieHealthRecovery(hPlayer)
+    end
+end
+
+function ApplyZombieHealthRecovery(hPlayer)
+    if not g_PlayerNextRecoveryTime[hPlayer:GetEntityIndex()] or Time() > g_PlayerNextRecoveryTime[hPlayer:GetEntityIndex()] then
+        if hPlayer:GetTeam() == CS_TEAM_T and hPlayer:IsAlive() then
+            hPlayer:SetHealth(math.min(hPlayer:GetHealth() + 350, g_PlayerHealthRecord[hPlayer:GetEntityIndex()] or ZOMBIE_HEALTH_DEFAULT_VALUE))
+            g_PlayerNextRecoveryTime[hPlayer:GetEntityIndex()] = Time() + 1
+        end
+    end
+end

--- a/scripts/vscripts/ZombieReborn/util/functions.lua
+++ b/scripts/vscripts/ZombieReborn/util/functions.lua
@@ -5,6 +5,10 @@ function EHandleToHScript(iPawnId)
     return EntIndexToHScript(bit.band(iPawnId, 0x3FFF))
 end
 
+function PrintLuaError(e)
+    print("Lua error: " .. e .. "\n" .. debug.traceback())
+end
+
 --Dump the contents of a table
 function table.dump(tbl)
     for k, v in pairs(tbl) do


### PR DESCRIPTION
1. Mother zombies gets lots of health, based on player num.
2. Mutant zombies gets half health of the attacker.
3. Zombies will recover some health when not being attacked.