### PR TITLE
Remove FirstInfection timer on Round Start

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -42,6 +42,8 @@ function OnRoundStart(event)
     SetupRepeatKiller()
     SetupAmmoReplenish()
     
+    Timers:RemoveTimer("MZSelection_Timer")
+    
     ZR_ROUND_STARTED = true
 end
 


### PR DESCRIPTION
Timers:CreateTimer() uses info_target entity for it's timers which means that if round ends during First Infection countdown, the countdown will carry on to the next round