### PR TITLE
Round End

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -104,7 +104,7 @@ function OnPlayerDeath(event)
         if player:GetTeam() == CS_TEAM_CT then
             --ignore if the player on ct team is the current hVictim
             --since they have yet to switch team from Infect
-            if player ~= hVictim or not player:IsAlive() then
+            if player ~= hVictim and player:IsAlive() then
                 return
             end
         end

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -34,8 +34,9 @@ function OnRoundStart(event)
         clientcmd = SpawnEntityFromTableSynchronous("point_clientcommand", {targetname="vscript_clientcommand"})
     end
 
-    Convars:SetInt("mp_respawn_on_death_t",1)
-    Convars:SetInt('mp_ignore_round_win_conditions',1)
+    print("Enabling spawn for T")
+    Convars:SetInt("mp_respawn_on_death_t", 1)
+    --Convars:SetInt('mp_ignore_round_win_conditions',1)
     ScriptPrintMessageChatAll("The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.")
     
     SetAllHuman()
@@ -83,14 +84,35 @@ function OnPlayerDeath(event)
 
     --Prevent Infecting the player in the same tick as the player dying
     if hAttacker:GetTeam() == CS_TEAM_T and hVictim:GetTeam() == CS_TEAM_CT then
-        DoEntFireByInstanceHandle(hVictim, "runscriptcode", "Infect(nil, thisEntity, true)", 0, nil, nil)
+        DoEntFireByInstanceHandle(hVictim, "runscriptcode", "Infect(nil, thisEntity, true)", 0.01, nil, nil)
     end
 
     -- Infect Humans that died after first infection has started
     if ZR_ROUND_STARTED and ZR_ZOMBIE_SPAWNED and hVictim:GetTeam() == CS_TEAM_CT then
         --Prevent Infecting the player in the same tick as the player dying
-        DoEntFireByInstanceHandle(hVictim, "runscriptcode", "Infect(nil, thisEntity, false)", 0.1, nil, nil)
+        DoEntFireByInstanceHandle(hVictim, "runscriptcode", "Infect(nil, thisEntity, false)", 0.01, nil, nil)
     end
+
+    --Allow the round to end if there's no CT left
+    --ignore if zombie has yet to spawn
+    if not ZR_ZOMBIE_SPAWNED then
+        return
+    end
+
+    local tPlayerTable = Entities:FindAllByClassname("player")
+    for _, player in ipairs(tPlayerTable) do
+        if player:GetTeam() == CS_TEAM_CT then
+            --ignore if the player on ct team is the current hVictim
+            --since they have yet to switch team from Infect
+            if player ~= hVictim or not player:IsAlive() then
+                return
+            end
+        end
+    end
+
+    print("Disabling spawn for T")
+    --Side effect: the last player infected/died doesn't respawn until the next round start
+    Convars:SetInt("mp_respawn_on_death_t", 0)
 end
 
 -- Infect late spawners

--- a/scripts/vscripts/ZombieReborn/RepeatKiller.lua
+++ b/scripts/vscripts/ZombieReborn/RepeatKiller.lua
@@ -14,12 +14,12 @@ end
 function ToggleRepeatKiller()
     if bRepeatKillerToggle == false then
         DoEntFireByInstanceHandle(hRelay, "RunScriptCode", "Convars:SetInt('mp_respawn_on_death_t',0)", 0, nil, nil)
-        DoEntFireByInstanceHandle(hRelay, "RunScriptCode", "Convars:SetInt('mp_ignore_round_win_conditions',0)", 0, nil, nil)
+        --DoEntFireByInstanceHandle(hRelay, "RunScriptCode", "Convars:SetInt('mp_ignore_round_win_conditions',0)", 0, nil, nil)
         ScriptPrintMessageChatAll(" \x04[Zombie:Reborn]\x01 Respawning disabled!")
     end
     if bRepeatKillerToggle == true then
         DoEntFireByInstanceHandle(hRelay, "RunScriptCode", "Convars:SetInt('mp_respawn_on_death_t',1)", 0, nil, nil)
-        DoEntFireByInstanceHandle(hRelay, "RunScriptCode", "Convars:SetInt('mp_ignore_round_win_conditions',1)", 0, nil, nil)
+        --DoEntFireByInstanceHandle(hRelay, "RunScriptCode", "Convars:SetInt('mp_ignore_round_win_conditions',1)", 0, nil, nil)
         ScriptPrintMessageChatAll(" \x04[Zombie:Reborn]\x01 Respawning enabled!")
     end
 


### PR DESCRIPTION
Allow the round to end when all CTs are dead
- Modified OnPlayerDeath hook to set mp_respawn_on_death_t to false when there's no one left in CT team
- Commented out redundant mp_ignore_round_win_conditions as mp_respawn_on_death_t already prevents the round from ending