### PR TITLE
Fix mother zombie infection always operating on the same table

### DIFF
--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -50,14 +50,13 @@ function Infect_PickMotherZombies()
     -- If the player is skipped, next random player is picked to be mother zombie (and same skip chance logic applies to him)
     -- the variable gets decreased by 20 every round (if it exists inside player's scope)
     local function PickMotherZombies()
-        
         -- No players to choose from
         if tPlayerTable == nil or #tPlayerTable == 0 then
             iMotherZombieCount = #tMotherZombies
             return
         end
         
-        local tPlayerTableShuffled = table.shuffle(tPlayerTable)
+        local tPlayerTableShuffled = table.shuffle(vlua.clone(tPlayerTable))
 
         for idx = 1, #tPlayerTableShuffled do
             local hPlayer = tPlayerTableShuffled[idx]


### PR DESCRIPTION
`tPlayerTable` was being passed by reference into `tPlayerTableShuffled` previously. This started breaking very frequently with lower player counts because of `table.RemoveValue(tPlayerTable, hPlayer)`, which was effectively removing the value from `tPlayerTableShuffled` as well, which shouldn't happen.

With the table cloned, operations on each table are now separate as intended by the selection logic.