### PR TITLE
table utility function; color field modify

### DIFF
--- a/cfg/zr/playerclass.cfg
+++ b/cfg/zr/playerclass.cfg
@@ -37,14 +37,15 @@
                 25 = "characters/models/ctm_fbi/ctm_fbi_variantg.vmdl"
                 26 = "characters/models/ctm_fbi/ctm_fbi_varianth.vmdl"
             }
-            "model_count" = 26
             "health" = 100
             "speed" = 1.0
             "scale" = 1.0
             "gravity" = 1.0
-            "colorR" = 255
-            "colorG" = 255
-            "colorB" = 255
+            "color" = {
+                r = 255
+                g = 255
+                b = 255
+            }
         }
         "StupidClass1"
         {
@@ -65,14 +66,15 @@
                 2="characters/models/tm_jumpsuit/tm_jumpsuit_variantb.vmdl"
                 3="characters/models/tm_jumpsuit/tm_jumpsuit_variantc.vmdl"
             }
-            "model_count" = 3
             "health" = 10000
             "speed" = 1.05
             "scale" = 1.05
             "gravity" = 1.0
-            "colorR" = 255
-            "colorG" = 150
-            "colorB" = 150
+            "color" = {
+                r = 255
+                g = 150
+                b = 150
+            }
             "health_regen_count" = 250
             "health_regen_interval" = 5
         }
@@ -80,14 +82,15 @@
             "model"{
                 1="characters/models/tm_phoenix_heavy/tm_phoenix_heavy.vmdl"
             }
-            "model_count" = 1
             "health" = 40000
             "speed" = 1.15
             "scale" = 1.15
             "gravity" = 0.9
-            "colorR" = 255
-            "colorG" = 100
-            "colorB" = 100
+            "color" = {
+                r = 255
+                g = 100
+                b = 100
+            }
             "health_regen_count" = 500
             "health_regen_interval" = 5
         }

--- a/scripts/vscripts/ZombieReborn/PlayerClass.lua
+++ b/scripts/vscripts/ZombieReborn/PlayerClass.lua
@@ -64,12 +64,12 @@ function CPlayerHumanDefault:OnInjection()
     --accessing value indirectly through the player handle would also work
     --such as self.health. But this value might be overriden by mapper who would
     --like to set value directly on the player handle as well
-    local model = thisClass.model[tostring(RandomInt(1,thisClass.model_count))]
+    local model = thisClass.model[tostring(RandomInt(1,table.size(thisClass.model)))]
     self:SetModel(model)
     self:SetHealth(thisClass.health)
     self:SetMaxHealth(thisClass.health)
     self:SetAbsScale(thisClass.scale)
-    self:SetRenderColor(thisClass.colorR, thisClass.colorG, thisClass.colorB)
+    self:SetRenderColor(thisClass.color.r, thisClass.color.g, thisClass.color.b)
 end
 function CPlayerHumanDefault:IsClass(tClass)
     return self.zrclass == tClass
@@ -78,12 +78,12 @@ end
 --Do something when this class is injected onto the player
 function CPlayerZombieDefault:OnInjection()
     local thisClass = self.zrclass
-    local model = thisClass.model[tostring(RandomInt(1,thisClass.model_count))]
+    local model = thisClass.model[tostring(RandomInt(1,table.size(thisClass.model)))]
     self:SetModel(model)
     self:SetHealth(thisClass.health)
     self:SetMaxHealth(thisClass.health)
     self:SetAbsScale(thisClass.scale)
-    self:SetRenderColor(thisClass.colorR, thisClass.colorG, thisClass.colorB)
+    self:SetRenderColor(thisClass.color.r, thisClass.color.g, thisClass.color.b)
     --Start Regenerating health
     self:SetContextThink("Regen", self.Regen, 0)
 end
@@ -128,9 +128,9 @@ local CPlayerAdmin = {
     speed = 1,
     scale = 5,
     gravity = 0,
-    colorR = 0,
-	colorG = 0,
-	colorB = 0
+    color = {
+        r = 0, g = 0, b = 0
+    }
 }
 AddHumanClass(CPlayerAdmin, "Admin")
 function CPlayerAdmin:LaunchGrenade()

--- a/scripts/vscripts/ZombieReborn/util/functions.lua
+++ b/scripts/vscripts/ZombieReborn/util/functions.lua
@@ -22,6 +22,14 @@ function table.shuffle(tbl)
     return tbl
 end
 
+function table.size(tbl)
+    local getN = 0
+    for _ in pairs(tbl) do 
+        getN = getN + 1 
+    end
+    return getN
+end
+
 -- removes all instances of a given value
 -- from a given table
 function table.RemoveValue(tbl, value)


### PR DESCRIPTION
add table.size(), see [here](https://stackoverflow.com/questions/2705793/how-to-get-number-of-entries-in-a-lua-table)
> removed model_count due to this function

convert `ColorR, ColorG, ColorB` to `color.{r, g, b}`, aka

prev: 
```
colorR = 255
colorG = 255
colorB = 255
```
now:
```
color = {
    r = 255
    g = 255
    b = 255
}
```