### PR TITLE
Use type specifiers to enable autocompletion

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -12,7 +12,7 @@ require("ZombieReborn.AmmoReplenish")
 require("ZombieReborn.PlayerClass")
 
 ZR_ROUND_STARTED = false
-ZR_ZOMBIE_SPAWNED = false -- Check if first zombie spawned
+ZR_ZOMBIE_SPAWNED = false     -- Check if first zombie spawned
 ZR_ZOMBIE_SPAWN_READY = false -- Check if first zombie is spawning
 
 Convars:SetInt("mp_autoteambalance", 0)
@@ -49,7 +49,8 @@ function OnRoundStart(event)
     --Convars:SetInt('mp_ignore_round_win_conditions',1)
 
     --print("Enabling spawn for T")
-    ScriptPrintMessageChatAll("The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.")
+    ScriptPrintMessageChatAll(
+        "The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.")
 
     --Setup various functions and gameplay elements
     SetAllHuman()
@@ -81,8 +82,8 @@ function OnPlayerHurt(event)
     if event.weapon == "" or event.attacker_pawn == nil then
         return
     end
-    local hAttacker = EHandleToHScript(event.attacker_pawn)
-    local hVictim = EHandleToHScript(event.userid_pawn)
+    local hAttacker = EHandleToPlayerPawn(event.attacker_pawn)
+    local hVictim = EHandleToPlayerPawn(event.userid_pawn)
 
     if hAttacker:GetTeam() == CS_TEAM_CT and hVictim:GetTeam() == CS_TEAM_T then
         Knockback_Apply(hAttacker, hVictim, event.dmg_health, event.weapon)
@@ -98,8 +99,8 @@ function OnPlayerDeath(event)
     -- if event.weapon == "" or event.attacker_pawn == -1 then
     --     return
     -- end
-    local hAttacker = EHandleToHScript(event.attacker_pawn)
-    local hVictim = EHandleToHScript(event.userid_pawn)
+    local hAttacker = EHandleToPlayerPawn(event.attacker_pawn)
+    local hVictim = EHandleToPlayerPawn(event.userid_pawn)
 
     --When player died from switching team, their GetTeam() is the team they are switching to
     --ignore zombie or during round start
@@ -128,7 +129,7 @@ end
 
 function OnPlayerSpawn(event)
     --__DumpScope(0, event)
-    local hPlayer = EHandleToHScript(event.userid_pawn)
+    local hPlayer = EHandleToPlayerPawn(event.userid_pawn)
 
     -- Infect late spawners & change mother zombie who died back to normal zombie
     if ZR_ZOMBIE_SPAWNED and tCureList[hPlayer] == nil then
@@ -146,8 +147,7 @@ end
 
 function OnItemEquip(event)
     --__DumpScope(0, event)
-    local hPlayer = EHandleToHScript(event.userid_pawn)
-
+    local hPlayer = EHandleToPlayerPawn(event.userid_pawn)
     if hPlayer:GetTeam() == CS_TEAM_T then
         local tInventory = hPlayer:GetEquippedWeapons()
 
@@ -167,7 +167,7 @@ end
 
 function OnPlayerTeam(event)
     --__DumpScope(0, event)
-    local hPlayer = EHandleToHScript(event.userid_pawn)
+    local hPlayer = EHandleToPlayerPawn(event.userid_pawn)
     if ZR_ZOMBIE_SPAWNED and event.team == CS_TEAM_CT and tCureList[hPlayer] == nil then
         --SetTeam doesn't work on the same tick as well :pepemeltdown:
         DoEntFireByInstanceHandle(hPlayer, "runscriptcode", "thisEntity:SetTeam(CS_TEAM_T)", 0.01, nil, nil)

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -12,7 +12,7 @@ require("ZombieReborn.AmmoReplenish")
 require("ZombieReborn.PlayerClass")
 
 ZR_ROUND_STARTED = false
-ZR_ZOMBIE_SPAWNED = false     -- Check if first zombie spawned
+ZR_ZOMBIE_SPAWNED = false -- Check if first zombie spawned
 ZR_ZOMBIE_SPAWN_READY = false -- Check if first zombie is spawning
 
 Convars:SetInt("mp_autoteambalance", 0)
@@ -49,8 +49,7 @@ function OnRoundStart(event)
     --Convars:SetInt('mp_ignore_round_win_conditions',1)
 
     --print("Enabling spawn for T")
-    ScriptPrintMessageChatAll(
-        "The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.")
+    ScriptPrintMessageChatAll("The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.")
 
     --Setup various functions and gameplay elements
     SetAllHuman()

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -81,8 +81,8 @@ function OnPlayerHurt(event)
     if event.weapon == "" or event.attacker_pawn == nil then
         return
     end
-    local hAttacker = EHandleToPlayerPawn(event.attacker_pawn)
-    local hVictim = EHandleToPlayerPawn(event.userid_pawn)
+    local hAttacker = EHandleToHScript(event.attacker_pawn)
+    local hVictim = EHandleToHScript(event.userid_pawn)
 
     if hAttacker:GetTeam() == CS_TEAM_CT and hVictim:GetTeam() == CS_TEAM_T then
         Knockback_Apply(hAttacker, hVictim, event.dmg_health, event.weapon)
@@ -98,8 +98,8 @@ function OnPlayerDeath(event)
     -- if event.weapon == "" or event.attacker_pawn == -1 then
     --     return
     -- end
-    local hAttacker = EHandleToPlayerPawn(event.attacker_pawn)
-    local hVictim = EHandleToPlayerPawn(event.userid_pawn)
+    local hAttacker = EHandleToHScript(event.attacker_pawn)
+    local hVictim = EHandleToHScript(event.userid_pawn)
 
     --When player died from switching team, their GetTeam() is the team they are switching to
     --ignore zombie or during round start
@@ -128,7 +128,7 @@ end
 
 function OnPlayerSpawn(event)
     --__DumpScope(0, event)
-    local hPlayer = EHandleToPlayerPawn(event.userid_pawn)
+    local hPlayer = EHandleToHScript(event.userid_pawn)
 
     -- Infect late spawners & change mother zombie who died back to normal zombie
     if ZR_ZOMBIE_SPAWNED and tCureList[hPlayer] == nil then
@@ -146,7 +146,7 @@ end
 
 function OnItemEquip(event)
     --__DumpScope(0, event)
-    local hPlayer = EHandleToPlayerPawn(event.userid_pawn)
+    local hPlayer = EHandleToHScript(event.userid_pawn)
     if hPlayer:GetTeam() == CS_TEAM_T then
         local tInventory = hPlayer:GetEquippedWeapons()
 
@@ -166,7 +166,7 @@ end
 
 function OnPlayerTeam(event)
     --__DumpScope(0, event)
-    local hPlayer = EHandleToPlayerPawn(event.userid_pawn)
+    local hPlayer = EHandleToHScript(event.userid_pawn)
     if ZR_ZOMBIE_SPAWNED and event.team == CS_TEAM_CT and tCureList[hPlayer] == nil then
         --SetTeam doesn't work on the same tick as well :pepemeltdown:
         DoEntFireByInstanceHandle(hPlayer, "runscriptcode", "thisEntity:SetTeam(CS_TEAM_T)", 0.01, nil, nil)

--- a/scripts/vscripts/ZombieReborn/Knockback.lua
+++ b/scripts/vscripts/ZombieReborn/Knockback.lua
@@ -32,7 +32,7 @@ end
 tRecordedGrenadePosition = {}
 function Knockback_OnGrenadeDetonate(event)
     --__DumpScope(0, event)
-    local hThrower = EHandleToPlayerPawn(event.userid_pawn)
+    local hThrower = EHandleToHScript(event.userid_pawn)
     local vecDetonatePosition = Vector(event.x, event.y, event.z)
     tRecordedGrenadePosition[hThrower] = vecDetonatePosition
 end
@@ -40,7 +40,7 @@ end
 tRecordedMolotovPosition = {}
 function Knockback_OnMolotovDetonate(event)
     --__DumpScope(0, event)
-    local hThrower = EHandleToPlayerPawn(event.userid_pawn)
+    local hThrower = EHandleToHScript(event.userid_pawn)
     local vecDetonatePosition = Vector(event.x, event.y, event.z)
     tRecordedMolotovPosition[hThrower] = vecDetonatePosition
 end

--- a/scripts/vscripts/ZombieReborn/Knockback.lua
+++ b/scripts/vscripts/ZombieReborn/Knockback.lua
@@ -32,7 +32,7 @@ end
 tRecordedGrenadePosition = {}
 function Knockback_OnGrenadeDetonate(event)
     --__DumpScope(0, event)
-    local hThrower = EHandleToHScript(event.userid_pawn)
+    local hThrower = EHandleToPlayerPawn(event.userid_pawn)
     local vecDetonatePosition = Vector(event.x, event.y, event.z)
     tRecordedGrenadePosition[hThrower] = vecDetonatePosition
 end
@@ -40,7 +40,7 @@ end
 tRecordedMolotovPosition = {}
 function Knockback_OnMolotovDetonate(event)
     --__DumpScope(0, event)
-    local hThrower = EHandleToHScript(event.userid_pawn)
+    local hThrower = EHandleToPlayerPawn(event.userid_pawn)
     local vecDetonatePosition = Vector(event.x, event.y, event.z)
     tRecordedMolotovPosition[hThrower] = vecDetonatePosition
 end

--- a/scripts/vscripts/ZombieReborn/util/functions.lua
+++ b/scripts/vscripts/ZombieReborn/util/functions.lua
@@ -5,6 +5,11 @@ function EHandleToHScript(iPawnId)
     return EntIndexToHScript(bit.band(iPawnId, 0x3FFF))
 end
 
+---@return CBasePlayerPawn
+function EHandleToPlayerPawn(iPawnId)
+    return EntIndexToHScript(bit.band(iPawnId, 0x3FFF))
+end
+
 --Dump the contents of a table
 function table.dump(tbl)
     for k, v in pairs(tbl) do

--- a/scripts/vscripts/ZombieReborn/util/functions.lua
+++ b/scripts/vscripts/ZombieReborn/util/functions.lua
@@ -1,12 +1,8 @@
 -- put your fancy global functions here for you (and others) to use, i guess
 
 -- Apparently entity indices take up the first 14 bits of an EHandle, need more testing to really verify this
-function EHandleToHScript(iPawnId)
-    return EntIndexToHScript(bit.band(iPawnId, 0x3FFF))
-end
-
 ---@return CBasePlayerPawn
-function EHandleToPlayerPawn(iPawnId)
+function EHandleToHScript(iPawnId)
     return EntIndexToHScript(bit.band(iPawnId, 0x3FFF))
 end
 


### PR DESCRIPTION
Enables type completions when using the vscode extensions:
[Lua Extension](https://marketplace.visualstudio.com/items?itemName=sumneko.lua)
[CS2 Vscript Natives](https://marketplace.visualstudio.com/items?itemName=poggudev.cs2-vscript-natives&ssr=false#overview)