### PR TITLE
Fix SetAllHuman() error after a player disconnects

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -68,7 +68,7 @@ function SetAllHuman()
     for i = 1, 64 do
         local hController = EntIndexToHScript(i)
 
-        if hController ~= nil then
+        if hController ~= nil and hController:GetPawn() ~= nil then
             Cure(hController:GetPawn(), true)
         end
     end


### PR DESCRIPTION
The controllers of players seem to stick around even after they disconnect, however their pawns do not. This meant that null pawns were being passed to Cure after players disconnected and erroring.