### PR TITLE
infect crash fix

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -17,6 +17,7 @@ ZR_ZOMBIE_SPAWN_READY = false -- Check if first zombie is spawning
 
 Convars:SetInt("mp_autoteambalance", 0)
 Convars:SetInt("mp_limitteams", 0)
+Convars:SetStr("bot_quota_mode", "fill")
 
 --remove duplicated listeners upon manual reload
 if tListenerIds then
@@ -78,7 +79,7 @@ end
 
 function OnPlayerHurt(event)
     --__DumpScope(0, event)
-    if event.weapon == "" or event.attacker_pawn == nil then
+    if event.weapon == "" or event.attacker_pawn == nil or event.dmg_health == ZR_INFECT_DAMAGE then
         return
     end
     local hAttacker = EHandleToHScript(event.attacker_pawn)

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -17,7 +17,6 @@ ZR_ZOMBIE_SPAWN_READY = false -- Check if first zombie is spawning
 
 Convars:SetInt("mp_autoteambalance", 0)
 Convars:SetInt("mp_limitteams", 0)
-Convars:SetStr("bot_quota_mode", "fill")
 
 --remove duplicated listeners upon manual reload
 if tListenerIds then
@@ -47,6 +46,7 @@ function OnRoundStart(event)
     Convars:SetInt("mp_friendlyfire", 0)
     Convars:SetInt("mp_respawn_on_death_t", 1)
     Convars:SetInt("mp_respawn_on_death_ct", 1)
+    Convars:SetStr("bot_quota_mode", "fill")
     --Convars:SetInt('mp_ignore_round_win_conditions',1)
 
     --print("Enabling spawn for T")

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -1,3 +1,5 @@
+ZR_INFECT_DAMAGE = 3141
+
 function Infect(hInflictor, hInfected, bKeepPosition)
     local vecOrigin = hInfected:GetOrigin()
     local vecAngles = hInfected:EyeAngles()
@@ -7,7 +9,7 @@ function Infect(hInflictor, hInfected, bKeepPosition)
     if hInflictor then
         --SOS: Cannot get hAttacker to work
         --CTakeDamageInfo CreateDamageInfo (handle hInflictor, handle hAttacker, Vector force, Vector hitPos, float flDamage, int damageTypes)
-        local cDamageInfo = CreateDamageInfo(hInflictor, nil, Vector(0, 0, 100), Vector(0, 0, 0), 1000, DMG_BULLET)
+        local cDamageInfo = CreateDamageInfo(hInflictor, nil, Vector(0, 0, 100), Vector(0, 0, 0), ZR_INFECT_DAMAGE, DMG_BULLET)
         hInfected:TakeDamage(cDamageInfo)
         DestroyDamageInfo(cDamageInfo)
     end


### PR DESCRIPTION
The crash was caused by an infinite loop inside playerhurt when a player was infected via knifing.
This solution uses an unique infect damage value to check against and return early.