### PR TITLE
Delay infection if the human was killed by the knife itself

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -88,7 +88,7 @@ function OnPlayerHurt(event)
     if hAttacker:GetTeam() == CS_TEAM_CT and hVictim:GetTeam() == CS_TEAM_T then
         Knockback_Apply(hAttacker, hVictim, event.dmg_health, event.weapon)
     elseif hAttacker:GetTeam() == CS_TEAM_T and hVictim:GetTeam() == CS_TEAM_CT then
-        Infect(hAttacker, hVictim, true)
+        Infect(hAttacker, hVictim, true, event.health == 0)
     end
 end
 

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -1,8 +1,14 @@
 ZR_INFECT_DAMAGE = 3141
 
-function Infect(hInflictor, hInfected, bKeepPosition)
+function Infect(hInflictor, hInfected, bKeepPosition, bDead)
     local vecOrigin = hInfected:GetOrigin()
     local vecAngles = hInfected:EyeAngles()
+
+    --Human was already killed by the knife itself, delay the infection a bit
+    if bDead then
+        InfectAsync(hInfected, bKeepPosition, false)
+        return
+    end
 
     --Give proper kill credit
     --By killing the player before they suicide from SetTeam
@@ -28,8 +34,8 @@ function Infect(hInflictor, hInfected, bKeepPosition)
     hInfected:SetAngles(vecAngles.x, vecAngles.y, vecAngles.z)
 end
 
-function InfectAsync(hInfected, bKeepPosition)
-    DoEntFireByInstanceHandle(hInfected, "runscriptcode", "Infect(nil, thisEntity, " .. tostring(bKeepPosition) .. ")", 0.01, nil, nil)
+function InfectAsync(hInfected, bKeepPosition, bKilled)
+    DoEntFireByInstanceHandle(hInfected, "runscriptcode", "Infect(nil, thisEntity, " .. tostring(bKeepPosition) .. "," .. tostring(bKilled) .. ")", 0.01, nil, nil)
 end
 
 tCureList = {}
@@ -123,7 +129,7 @@ function Infect_PickMotherZombies()
     -- (in the future, when we surely get access to player's steamid and nickname from lua)
 
     for index, player in pairs(tMotherZombies) do
-        Infect(nil, player, bSpawnType)
+        Infect(nil, player, bSpawnType, false)
     end
     print("Player count: " .. iPlayerCount .. ", Mother Zombies Spawned: " .. iMotherZombieCount)
 


### PR DESCRIPTION
It seems that something weird is happening between the moment a player dies by a weapon and the infection team switch, in this case it resulted in the team switch somehow killing the player instead. Team switches don't trigger round ends for whatever reason so we're left with this mess.