### PR TITLE
Fix a couple crashes

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -70,7 +70,8 @@ function SetAllHuman()
         local hController = EntIndexToHScript(i)
 
         if hController ~= nil and hController:GetPawn() ~= nil then
-            Cure(hController:GetPawn(), true)
+            --I have absolutely no idea why, but this has to be delayed now
+            CureAsync(hController:GetPawn(), true)
         end
     end
 

--- a/scripts/vscripts/ZombieReborn/Convars.lua
+++ b/scripts/vscripts/ZombieReborn/Convars.lua
@@ -4,6 +4,7 @@ Convars:RegisterConvar("zr_infect_spawn_time_min", "15", "Minimum time in which 
 Convars:RegisterConvar("zr_infect_spawn_time_max", "15", "Maximum time in which Mother Zombies should be picked, after round start", FCVAR_RELEASE)
 Convars:RegisterConvar("zr_infect_spawn_mz_ratio", "7", "Ratio of all Players to Mother Zombies to be spawned at round start", FCVAR_RELEASE)
 Convars:RegisterConvar("zr_infect_spawn_mz_min_count", "2", "Minimum amount of Mother Zombies to be spawned at round start", FCVAR_RELEASE)
+Convars:RegisterConvar("zr_debug_print", "0", "Whether to print extra information during infection or curing", FCVAR_RELEASE)
 
 -- Knockback
 Convars:RegisterConvar("zr_knockback_scale", "5", "Knockback damage multiplier", FCVAR_RELEASE)

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -8,6 +8,9 @@ function Infect(hInflictor, hInfected, bKeepPosition, bDead)
     if bDead then
         InfectAsync(hInfected, bKeepPosition, false)
         return
+    elseif hInfected:GetHealth() == 0 then
+        --Infect was called on a spectator somehow during initial infection, nope out
+        return
     end
 
     --Give proper kill credit

--- a/scripts/vscripts/ZombieReborn/PlayerClass.lua
+++ b/scripts/vscripts/ZombieReborn/PlayerClass.lua
@@ -91,9 +91,11 @@ function CPlayerHumanBase:OnInjection()
     --like to set value directly on the player handle as well
     local model = thisClass.model[tostring(RandomInt(1, table.size(thisClass.model)))]
     self:SetModel(model)
+    DebugPrint("CPlayerHumanBase:OnInjection: Model set")
     self:SetMaxHealth(thisClass.health)
     self:SetHealth(thisClass.health)
     self:SetAbsScale(thisClass.scale)
+    DebugPrint("CPlayerHumanBase:OnInjection: Scale set to " .. thisClass.scale)
     self:SetRenderColor(thisClass.color.r, thisClass.color.g, thisClass.color.b)
 end
 
@@ -102,9 +104,11 @@ function CPlayerZombieBase:OnInjection()
     local thisClass = self.zrclass
     local model = thisClass.model[tostring(RandomInt(1, table.size(thisClass.model)))]
     self:SetModel(model)
+    DebugPrint("CPlayerZombieBase:OnInjection: Model set")
     self:SetMaxHealth(thisClass.health)
     self:SetHealth(thisClass.health)
     self:SetAbsScale(thisClass.scale)
+    DebugPrint("CPlayerZombieBase:OnInjection: Scale set to " .. thisClass.scale)
     self:SetRenderColor(thisClass.color.r, thisClass.color.g, thisClass.color.b)
     --Start Regenerating health
     self:SetContextThink("Regen", self.Regen, 0)

--- a/scripts/vscripts/ZombieReborn/util/functions.lua
+++ b/scripts/vscripts/ZombieReborn/util/functions.lua
@@ -40,3 +40,9 @@ function table.RemoveValue(tbl, value)
         end
     end
 end
+
+function DebugPrint(message)
+    if Convars:GetInt("zr_debug_print") == 1 then
+        print(message)
+    end
+end


### PR DESCRIPTION
In some cases, like if you join spectators after spawning as CT, `GetTeam()` still returns the old team, so the player falls through into the initial infection table and it attempts to infect a spectator, which crashes.

I also had a crash upon starting a server, which was fixed by delaying the `Cure` at the start of a round. Can't bother to figure out why since it doesn't matter anyway.