### PR TITLE
Add workaround for mother zombie selection randomly crashing

### DIFF
--- a/scripts/vscripts/ZombieReborn/Convars.lua
+++ b/scripts/vscripts/ZombieReborn/Convars.lua
@@ -4,6 +4,9 @@ Convars:RegisterConvar("zr_infect_spawn_time_min", "15", "Minimum time in which 
 Convars:RegisterConvar("zr_infect_spawn_time_max", "15", "Maximum time in which Mother Zombies should be picked, after round start", FCVAR_RELEASE)
 Convars:RegisterConvar("zr_infect_spawn_mz_ratio", "7", "Ratio of all Players to Mother Zombies to be spawned at round start", FCVAR_RELEASE)
 Convars:RegisterConvar("zr_infect_spawn_mz_min_count", "2", "Minimum amount of Mother Zombies to be spawned at round start", FCVAR_RELEASE)
+Convars:RegisterConvar("zr_infect_spawn_crash_fix", "0", "Whether to use a poor workaround for Mother Zombie selection randomly crashing", FCVAR_RELEASE)
+
+-- Debug
 Convars:RegisterConvar("zr_debug_print", "0", "Whether to print extra information during infection or curing", FCVAR_RELEASE)
 
 -- Knockback

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -161,7 +161,7 @@ function Infect_PickMotherZombies()
 
     for index, player in pairs(tMotherZombies) do
         if Convars:GetInt("zr_infect_spawn_crash_fix") == 1 then
-            DoEntFireByInstanceHandle(player , "SetHealth", "0", 0.01, nil, nil)
+            DoEntFireByInstanceHandle(player, "SetHealth", "0", 0.01, nil, nil)
         else
             Infect(nil, player, bSpawnType, false)
         end

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -156,13 +156,17 @@ function Infect_PickMotherZombies()
 
     DebugPrint("Infect_PickMotherZombies: Infecting mother zombies")
 
-    for index, player in pairs(tMotherZombies) do
-        Infect(nil, player, bSpawnType, false)
-    end
-    print("Player count: " .. iPlayerCount .. ", Mother Zombies Spawned: " .. iMotherZombieCount)
-
     -- Mother zombie spawned
     ZR_ZOMBIE_SPAWNED = true
+
+    for index, player in pairs(tMotherZombies) do
+        if Convars:GetInt("zr_infect_spawn_crash_fix") == 1 then
+            DoEntFireByInstanceHandle(player , "SetHealth", "0", 0.01, nil, nil)
+        else
+            Infect(nil, player, bSpawnType, false)
+        end
+    end
+    print("Player count: " .. iPlayerCount .. ", Mother Zombies Spawned: " .. iMotherZombieCount)
 end
 
 function Infect_OnRoundFreezeEnd()


### PR DESCRIPTION
Implements the crash workaround @EasterLee posted in Discord during the last test. I've moved the functionality behind a cvar.

Certainly not ideal, especially since it immediately ends the round with only 1-2 players (nobody left alive), but is currently necessary for hosting live ZE sessions.