### PR TITLE
Add configuration for random model skins

### DIFF
--- a/cfg/zr/playerclass.cfg
+++ b/cfg/zr/playerclass.cfg
@@ -3,8 +3,8 @@
     "Human"
     {
         //every team must have a base class
-        "Base" 
-        {   
+        "Base"
+        {
             //class behavior, value will not be inherited
             "enabled" = 1 //if 0, this class will be ignored when parsing
             "team_default" = 1 //if 1, player on this team will be automatically assigned to this class, random if multiple class have this option enabled
@@ -43,6 +43,9 @@
                 25 = "characters/models/ctm_fbi/ctm_fbi_variantg.vmdl"
                 26 = "characters/models/ctm_fbi/ctm_fbi_varianth.vmdl"
             }
+            "max_skin_index"
+            {
+            }
             "health" = 100
             "speed" = 1.0
             "scale" = 1.0
@@ -74,7 +77,21 @@
                 g = 150
                 b = 255
             }
-            
+        }
+        "SkinExample"
+        {
+            "enabled" = 1
+            "team_default" = 1
+
+            "model"
+            {
+                1 = "characters/models/s2ze/isaac_clarke/isaac_clarke.vmdl"
+            }
+            "max_skin_index"
+            {
+                // Isaac Clarke model (at index 1) uses skin indexes 0-4
+                1 = 4
+            }
         }
     }
     "Zombie"
@@ -89,6 +106,9 @@
                 1="characters/models/tm_jumpsuit/tm_jumpsuit_varianta.vmdl"
                 2="characters/models/tm_jumpsuit/tm_jumpsuit_variantb.vmdl"
                 3="characters/models/tm_jumpsuit/tm_jumpsuit_variantc.vmdl"
+            }
+            "max_skin_index"
+            {
             }
             "health" = 10000
             "speed" = 1.05

--- a/scripts/vscripts/ZombieReborn/PlayerClass.lua
+++ b/scripts/vscripts/ZombieReborn/PlayerClass.lua
@@ -89,8 +89,16 @@ function CPlayerHumanBase:OnInjection()
     --accessing value indirectly through the player handle would also work
     --such as self.health. But this value might be overriden by mapper who would
     --like to set value directly on the player handle as well
-    local model = thisClass.model[tostring(RandomInt(1, table.size(thisClass.model)))]
+    local modelIndex = tostring(RandomInt(1, table.size(thisClass.model)))
+    local model = thisClass.model[modelIndex]
+    local maxSkinIndex = tonumber(thisClass.max_skin_index[modelIndex])
+
     self:SetModel(model)
+
+    if maxSkinIndex ~= nil then
+        DoEntFireByInstanceHandle(self, "skin", tostring(RandomInt(0, maxSkinIndex)), 0.01, nil, nil)
+    end
+
     DebugPrint("CPlayerHumanBase:OnInjection: Model set")
     self:SetMaxHealth(thisClass.health)
     self:SetHealth(thisClass.health)
@@ -102,8 +110,16 @@ end
 --Do something when this class is injected onto the player
 function CPlayerZombieBase:OnInjection()
     local thisClass = self.zrclass
-    local model = thisClass.model[tostring(RandomInt(1, table.size(thisClass.model)))]
+    local modelIndex = tostring(RandomInt(1, table.size(thisClass.model)))
+    local model = thisClass.model[modelIndex]
+    local maxSkinIndex = tonumber(thisClass.max_skin_index[modelIndex])
+
     self:SetModel(model)
+
+    if maxSkinIndex ~= nil then
+        DoEntFireByInstanceHandle(self, "skin", tostring(RandomInt(0, maxSkinIndex)), 0.01, nil, nil)
+    end
+
     DebugPrint("CPlayerZombieBase:OnInjection: Model set")
     self:SetMaxHealth(thisClass.health)
     self:SetHealth(thisClass.health)


### PR DESCRIPTION
Self explanatory, includes example config.

I considered going the route of supplying each skin index individually, for better flexibility, but was unable to come up with a nice way to implement this in keyvalues with our current config layout. This shouldn't matter for us anyways, since I imagine we'll just want to show off all the skins of our models in playtests.