### PR TITLE
Add convars for antistack and prevent error messages

### DIFF
--- a/scripts/vscripts/ZombieReborn/AntiStack.lua
+++ b/scripts/vscripts/ZombieReborn/AntiStack.lua
@@ -4,8 +4,9 @@ function testKnife(hPlayer)
         -- zombie has already knifed someone
         return
     end
+    local knifeRange = Convars:GetInt("zr_antistack_range")
     local vecStart = hPlayer:EyePosition()
-    local vecEnd = vecStart + hPlayer:EyeAngles():Forward() * 48
+    local vecEnd = vecStart + hPlayer:EyeAngles():Forward() * knifeRange
     local traceData = {
         startpos = vecStart,
         endpos = vecEnd,
@@ -14,7 +15,7 @@ function testKnife(hPlayer)
     TraceLine(traceData)
     vecEnd = traceData.pos
     --DebugDrawLine(vecStart, vecEnd, 255, 0, 0, false, 5)
-    local candidates = Entities:FindAllByClassnameWithin("player", vecStart, 120)
+    local candidates = Entities:FindAllByClassnameWithin("player", vecStart, 72 + knifeRange)
     for i, v in ipairs(candidates) do
         if v:GetTeam() == CS_TEAM_CT and v:IsAlive() then
             local traceData2 = {
@@ -36,6 +37,9 @@ function testKnife(hPlayer)
 end
 
 local OnWeaponFired = function(event)
+    if Convars:GetInt("zr_antistack_enable") == 0 then
+        return
+    end
     local hPlayer = EHandleToHScript(event.userid_pawn)
     if hPlayer:GetTeam() ~= CS_TEAM_T then
         return
@@ -46,6 +50,9 @@ local OnWeaponFired = function(event)
 end
 
 local OnPlayerHurt = function(event)
+    if Convars:GetInt("zr_antistack_enable") == 0 or event.weapon == "" or event.attacker_pawn == nil then
+        return
+    end
     local hAttacker = EHandleToHScript(event.attacker_pawn)
     local hVictim = EHandleToHScript(event.userid_pawn)
     if hAttacker:GetTeam() ~= CS_TEAM_T or hVictim:GetTeam() ~= CS_TEAM_CT then

--- a/scripts/vscripts/ZombieReborn/Convars.lua
+++ b/scripts/vscripts/ZombieReborn/Convars.lua
@@ -11,3 +11,7 @@ Convars:RegisterConvar("zr_debug_print", "0", "Whether to print extra informatio
 
 -- Knockback
 Convars:RegisterConvar("zr_knockback_scale", "5", "Knockback damage multiplier", FCVAR_RELEASE)
+
+-- AntiStack
+Convars:RegisterConvar("zr_antistack_enable", "0", "Temporary fix to allow zombie knife through each other", FCVAR_RELEASE)
+Convars:RegisterConvar("zr_antistack_range", "20", "AntiStack knife range", FCVAR_RELEASE)


### PR DESCRIPTION
Two convars for antistack, one for enable/disable and one for knife range. The default range is made even shorter.
Also added a check for OnPlayerHurt to prevent error spam.