### PR TITLE
CS2Fixes team switching

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -54,7 +54,7 @@ function OnRoundStart(event)
     ScriptPrintMessageChatAll("The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.")
 
     --Setup various functions and gameplay elements
-    SetAllHuman()
+    SetAllHumanClasses()
     SetupRespawnToggler()
     SetupAmmoReplenish()
 
@@ -63,25 +63,14 @@ function OnRoundStart(event)
     ZR_ROUND_STARTED = true
 end
 
-function SetAllHuman()
-    local bRespawn = Convars:GetBool("mp_respawn_on_death_ct")
-    Convars:SetBool("mp_respawn_on_death_ct", true)
-
+function SetAllHumanClasses()
     for i = 1, 64 do
         local hController = EntIndexToHScript(i)
 
-        if hController ~= nil and hController:GetPawn() ~= nil and hController:GetTeam() >= CS_TEAM_T then
-            if Convars:GetInt("zr_use_cs2fixes_team_switch") == 1 then
-                InjectPlayerClass(PickRandomHumanDefaultClass(), hController:GetPawn())
-            else
-                --I have absolutely no idea why, but this has to be delayed now
-                --CureAsync(hController:GetPawn(), true)
-                DoEntFireByInstanceHandle(hController:GetPawn(), "runscriptcode", "Cure(thisEntity, true)", i * 0.05, nil, nil)
-            end
+        if hController ~= nil and hController:GetPawn() ~= nil then
+            InjectPlayerClass(PickRandomHumanDefaultClass(), hController:GetPawn())
         end
     end
-
-    Convars:SetBool("mp_respawn_on_death_ct", bRespawn)
 end
 
 function OnPlayerHurt(event)
@@ -174,6 +163,15 @@ function OnRoundEnd(event)
     ZR_ZOMBIE_SPAWN_READY = false
 end
 
+function OnPreStart(event)
+    for i = 1, 64 do
+        local hController = EntIndexToHScript(i)
+        if hController ~= nil and hController:GetTeam() == CS_TEAM_T then
+            hController:SetTeam(CS_TEAM_CT)
+        end
+    end
+end
+
 function OnPlayerTeam(event)
     --__DumpScope(0, event)
     local hPlayer = EHandleToHScript(event.userid_pawn)
@@ -196,4 +194,5 @@ tListenerIds = {
     ListenToGameEvent("item_equip", OnItemEquip, nil),
     ListenToGameEvent("round_end", OnRoundEnd, nil),
     ListenToGameEvent("player_team", OnPlayerTeam, nil),
+    ListenToGameEvent("round_prestart", OnPreStart, nil),
 }

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -158,7 +158,8 @@ function OnItemEquip(event)
     end
 end
 
-function OnRoundEnd(event)
+-- Basically round_end
+function OnPreRestart(event)
     ZR_ZOMBIE_SPAWNED = false
     ZR_ZOMBIE_SPAWN_READY = false
 end
@@ -192,7 +193,7 @@ tListenerIds = {
     ListenToGameEvent("molotov_detonate", Knockback_OnMolotovDetonate, nil),
     ListenToGameEvent("round_freeze_end", Infect_OnRoundFreezeEnd, nil),
     ListenToGameEvent("item_equip", OnItemEquip, nil),
-    ListenToGameEvent("round_end", OnRoundEnd, nil),
+    ListenToGameEvent("cs_pre_restart", OnPreRestart, nil),
     ListenToGameEvent("player_team", OnPlayerTeam, nil),
     ListenToGameEvent("round_prestart", OnPreStart, nil),
 }

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -178,9 +178,9 @@ function OnPlayerTeam(event)
     local hPlayer = EHandleToHScript(event.userid_pawn)
     if ZR_ZOMBIE_SPAWNED and event.team == CS_TEAM_CT and tCureList[hPlayer] == nil then
         --SetTeam doesn't work on the same tick as well :pepemeltdown:
-        DoEntFireByInstanceHandle(hPlayer, "runscriptcode", "thisEntity:SetTeam(CS_TEAM_T)", 0.01, nil, nil)
+        DoEntFireByInstanceHandle(hPlayer, "runscriptcode", "thisEntity:SetTeam(CS_TEAM_NONE); thisEntity:SetTeam(CS_TEAM_T)", 0.01, nil, nil)
     elseif not ZR_ZOMBIE_SPAWN_READY and event.team == CS_TEAM_T then
-        DoEntFireByInstanceHandle(hPlayer, "runscriptcode", "thisEntity:SetTeam(CS_TEAM_CT)", 0.01, nil, nil)
+        DoEntFireByInstanceHandle(hPlayer, "runscriptcode", "thisEntity:SetTeam(CS_TEAM_NONE); thisEntity:SetTeam(CS_TEAM_CT)", 0.01, nil, nil)
     end
 end
 

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -70,10 +70,14 @@ function SetAllHuman()
     for i = 1, 64 do
         local hController = EntIndexToHScript(i)
 
-        if hController ~= nil and hController:GetPawn() ~= nil then
-            --I have absolutely no idea why, but this has to be delayed now
-            --CureAsync(hController:GetPawn(), true)
-            DoEntFireByInstanceHandle(hController:GetPawn(), "runscriptcode", "Cure(thisEntity, true)", i * 0.05, nil, nil)
+        if hController ~= nil and hController:GetPawn() ~= nil and hController:GetTeam() >= CS_TEAM_T then
+            if Convars:GetInt("zr_use_cs2fixes_team_switch") == 1 then
+                InjectPlayerClass(PickRandomHumanDefaultClass(), hController:GetPawn())
+            else
+                --I have absolutely no idea why, but this has to be delayed now
+                --CureAsync(hController:GetPawn(), true)
+                DoEntFireByInstanceHandle(hController:GetPawn(), "runscriptcode", "Cure(thisEntity, true)", i * 0.05, nil, nil)
+            end
         end
     end
 

--- a/scripts/vscripts/ZombieReborn/Convars.lua
+++ b/scripts/vscripts/ZombieReborn/Convars.lua
@@ -15,3 +15,5 @@ Convars:RegisterConvar("zr_knockback_scale", "5", "Knockback damage multiplier",
 -- AntiStack
 Convars:RegisterConvar("zr_antistack_enable", "0", "Temporary fix to allow zombie knife through each other", FCVAR_RELEASE)
 Convars:RegisterConvar("zr_antistack_range", "20", "AntiStack knife range", FCVAR_RELEASE)
+
+Convars:RegisterConvar("zr_use_cs2fixes_team_switch", "0", "Whether to rely on CS2Fixes' team switching on round start.", FCVAR_RELEASE)

--- a/scripts/vscripts/ZombieReborn/Convars.lua
+++ b/scripts/vscripts/ZombieReborn/Convars.lua
@@ -15,5 +15,3 @@ Convars:RegisterConvar("zr_knockback_scale", "5", "Knockback damage multiplier",
 -- AntiStack
 Convars:RegisterConvar("zr_antistack_enable", "0", "Temporary fix to allow zombie knife through each other", FCVAR_RELEASE)
 Convars:RegisterConvar("zr_antistack_range", "20", "AntiStack knife range", FCVAR_RELEASE)
-
-Convars:RegisterConvar("zr_use_cs2fixes_team_switch", "0", "Whether to rely on CS2Fixes' team switching on round start.", FCVAR_RELEASE)


### PR DESCRIPTION
Players are moved to CT by CS2Fixes right before the round switches, this is to avoid the mass suicide seen at the start of a round and potentially causing client crashes. In addition, ZR flags are now reset on `cs_pre_restart` instead of `round_end`, as the former fires consistently 1s before the new round starts.