### PR TITLE
Fix constant client crashes from Lua SetTeam

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -169,15 +169,6 @@ function OnPreRestart(event)
     ZR_ZOMBIE_SPAWN_READY = false
 end
 
-function OnPreStart(event)
-    for i = 1, 64 do
-        local hController = EntIndexToHScript(i)
-        if hController ~= nil and hController:GetTeam() == CS_TEAM_T then
-            hController:SetTeam(CS_TEAM_CT)
-        end
-    end
-end
-
 function OnPlayerTeam(event)
     --__DumpScope(0, event)
     local hPlayer = EHandleToHScript(event.userid_pawn)
@@ -200,5 +191,4 @@ tListenerIds = {
     ListenToGameEvent("item_equip", OnItemEquip, nil),
     ListenToGameEvent("cs_pre_restart", OnPreRestart, nil),
     ListenToGameEvent("player_team", OnPlayerTeam, nil),
-    ListenToGameEvent("round_prestart", OnPreStart, nil),
 }


### PR DESCRIPTION
Forceteams is already implemented in CS2Fixes, and setting team in Lua is extremely prone to client crashes. Lua had precedence at least some of the time, as it was running on the [same event as CS2Fixes](https://github.com/Source2ZE/CS2Fixes/blob/db679357c84e61c979623b15b1454537c128cf56/src/events.cpp#L69).