### PR TITLE
Mz selection tweak + properly assign human class

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -140,12 +140,11 @@ function OnPlayerSpawn(event)
         InfectAsync(hPlayer, false)
         return
     end
-    
+
     -- assign human class for those who missed the human class assignment
     if ZR_ROUND_STARTED and not ZR_ZOMBIE_SPAWNED and hPlayer:GetTeam() == CS_TEAM_CT then
         InjectPlayerClass(PickRandomHumanDefaultClass(), hPlayer)
     end
-
 end
 
 function OnItemEquip(event)

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -140,12 +140,12 @@ function OnPlayerSpawn(event)
         InfectAsync(hPlayer, false)
         return
     end
+    
+    -- assign human class for those who missed the human class assignment
+    if ZR_ROUND_STARTED and not ZR_ZOMBIE_SPAWNED and hPlayer:GetTeam() == CS_TEAM_CT then
+        InjectPlayerClass(PickRandomHumanDefaultClass(), hPlayer)
+    end
 
-    -- force switch team for player who tries to join the T side
-    -- if not ZR_ZOMBIE_SPAWN_READY and hPlayer:GetTeam() == CS_TEAM_T then
-    --     --print("Forcing player to ct")
-    --     CureAsync(hPlayer, false)
-    -- end
 end
 
 function OnItemEquip(event)

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -120,9 +120,9 @@ function Infect_PickMotherZombies()
     local iRemovedPlayers = 0
 
     -- remove players that belong to invalid teams from player table before proceeding with first infection logic
-    for key, player in ipairs(tPlayerTable) do
-        if player:GetTeam() < 2 then
-            table.remove(tPlayerTable, key)
+    for i = iPlayerCount, 1, -1 do
+        if tPlayerTable[i]:GetTeam() < 2 then
+            table.remove(tPlayerTable, i)
             iRemovedPlayers = iRemovedPlayers + 1
         end
     end
@@ -202,12 +202,12 @@ function Infect_OnRoundFreezeEnd()
     local iMZSpawntime = RandomInt(iMZSpawntimeMinimum, iMZSpawntimeMaximum)
 
     -- reduce mother zombie spawn skip chance for players who have that variable in their script scope
-    for k, player in pairs(Entities:FindAllByClassname("player")) do
-        local scope = player:GetOrCreatePrivateScriptScope()
-        if scope.MZSpawn_SkipChance then
-            scope.MZSpawn_SkipChance = scope.MZSpawn_SkipChance - 20
-        end
-    end
+    -- for k, player in pairs(Entities:FindAllByClassname("player")) do
+    --     local scope = player:GetOrCreatePrivateScriptScope()
+    --     if scope.MZSpawn_SkipChance then
+    --         scope.MZSpawn_SkipChance = scope.MZSpawn_SkipChance - 20
+    --     end
+    -- end
 
     -- announce time remaining to infection and do infection at countdown<=0
     local MZSelection_Countdown = iMZSpawntime


### PR DESCRIPTION
- Adjusted skip chance to prevent players from being picked twice in a row.
- Assign human class to those who connected after round_start