### PR TITLE
Changes to First Infection Skip Chance & Class Injection

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -143,7 +143,7 @@ function OnPlayerSpawn(event)
 
     -- assign human class for those who missed the human class assignment
     if ZR_ROUND_STARTED and not ZR_ZOMBIE_SPAWNED and hPlayer:GetTeam() == CS_TEAM_CT then
-        InjectPlayerClass(PickRandomHumanDefaultClass(), hPlayer)
+        DoEntFireByInstanceHandle(hPlayer, "RunScriptCode", "InjectPlayerClass(PickRandomHumanDefaultClass(), thisEntity)", 0.01, nil, nil)
     end
 end
 

--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -141,11 +141,10 @@ function OnPlayerSpawn(event)
         return
     end
 
-    -- force switch team for player who tries to join the T side
-    -- if not ZR_ZOMBIE_SPAWN_READY and hPlayer:GetTeam() == CS_TEAM_T then
-    --     --print("Forcing player to ct")
-    --     CureAsync(hPlayer, false)
-    -- end
+    -- assign human class for those who missed the human class assignment
+    if ZR_ROUND_STARTED and not ZR_ZOMBIE_SPAWNED and hPlayer:GetTeam() == CS_TEAM_CT then
+        InjectPlayerClass(PickRandomHumanDefaultClass(), hPlayer)
+    end
 end
 
 function OnItemEquip(event)

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -183,7 +183,7 @@ function Infect_PickMotherZombies()
             end
         end
         iFailSafeCounter = iFailSafeCounter - 1
-            
+
         DebugPrint("Infect_PickMotherZombies: Calling PickMotherZombies with " .. #tMotherZombies .. " out of " .. iMotherZombieCount .. " mother zombies chosen")
         PickMotherZombies()
     until #tMotherZombies == iMotherZombieCount

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -154,9 +154,10 @@ function Infect_PickMotherZombies()
             -- Roll for player's chance to skip being picked as MZ
             if RandomInt(1, 100) <= iSkipChance then
                 -- player succeeded the roll and avoided being picked as MZ
+                DebugPrint("Infect_PickMotherZombies:PickMotherZombies: Skipping a player during initial infection selection (SkipChance = " .. iSkipChance .. "%)")
             else
                 -- player failed the roll, pick him as MZ and set his Skip Chance to 100%
-                DebugPrint("Infect_PickMotherZombies:PickMotherZombies: Inserting a player into initial infection")
+                DebugPrint("Infect_PickMotherZombies:PickMotherZombies: Inserting a player into initial infection (SkipChance = " .. iSkipChance .. "%)")
                 tPlayerScope.MZSpawn_SkipChance = 100
                 table.insert(tMotherZombies, hPlayer)
 
@@ -170,7 +171,19 @@ function Infect_PickMotherZombies()
         end
     end
 
+    local iFailSafeCounter = 5
+
     repeat
+        -- If we somehow don't have enough mother zombies after going through the players table 5 times,
+        -- set Skip Chance of everyone but already picked mother zombies to 0
+        if iFailSafeCounter == 0 then
+            DebugPrint("Infect_PickMotherZombies: Not enough mother zombies after calling PickMotherZombies 5 times, resetting everyone's Skip Chance")
+            for i = 1, #tPlayerTable do
+                tPlayerTable[i]:GetOrCreatePrivateScriptScope().MZSpawn_SkipChance = 0
+            end
+        end
+        iFailSafeCounter = iFailSafeCounter - 1
+            
         DebugPrint("Infect_PickMotherZombies: Calling PickMotherZombies with " .. #tMotherZombies .. " out of " .. iMotherZombieCount .. " mother zombies chosen")
         PickMotherZombies()
     until #tMotherZombies == iMotherZombieCount


### PR DESCRIPTION
The current implementation of Skip Chance allows uncommon cases where a player can be picked as a mother zombie 2 (or even more) rounds in a row. While not problematic for the gamemode's functioning, it can be rather frustrating for the player it happens to. This PR fixes that behaviour and causes players picked as mother zombies to have immunity from being picked as MZ in the next round. In following rounds, player will still have high Skip Chance value (and there will be other players to pick), so the effect of players being MZs only once every couple rounds is still achieved. On average, at least.
This PR also adds a fail safe to the First Infection loop that resets everyone but already picked MZs' Skip Chances to 0, akin to CS:GO's Z:R resetting Infection Cycle. This should fire only in *very* fringe cases. I do not know if it's needed, but I've added it just in case.

Changes in this PR:
- Remove reduction to player's Skip Chance on avoiding being picked as a mother zombie
- Move per-round reduction of players Skip Chances to happen after mother zombies have been picked, and make it only reduce Skip Chance of players not picked as MZ (so MZ have 100% Skip Chance on next round)
- Include a fail safe that will reset everyone but mother zombies' Skip Chance in case the First Infection logic loops too many times without having picked enough MZs (no idea if it's necessary, added for good measure)