### PR TITLE
Add weapon type check before infection & Fix nade cooking issues

### DIFF
--- a/scripts/vscripts/ZombieReborn.lua
+++ b/scripts/vscripts/ZombieReborn.lua
@@ -83,7 +83,7 @@ function OnPlayerHurt(event)
 
     if hAttacker:GetTeam() == CS_TEAM_CT and hVictim:GetTeam() == CS_TEAM_T then
         Knockback_Apply(hAttacker, hVictim, event.dmg_health, event.weapon)
-    elseif hAttacker:GetTeam() == CS_TEAM_T and hVictim:GetTeam() == CS_TEAM_CT then
+    elseif event.weapon == "knife" and hAttacker:GetTeam() == CS_TEAM_T and hVictim:GetTeam() == CS_TEAM_CT then
         Infect(hAttacker, hVictim, true, event.health == 0)
     end
 end

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -33,14 +33,14 @@ function Infect(hInflictor, hInfected, bKeepPosition, bDead)
 
     -- Asynchronously kill any utils held by the infected player AND any nades threwn by said player
     local tHeldWeapons = hInfected:GetEquippedWeapons()
-    for _,hWeapon in ipairs(tHeldWeapons) do
+    for _, hWeapon in ipairs(tHeldWeapons) do
         if hWeapon and hWeapon:GetClassname() ~= "weapon_knife" then
             DoEntFireByInstanceHandle(hWeapon, "Kill", "", 0.02, nil, nil)
         end
     end
 
     local tThrewnNades = Entities:FindAllByClassname("hegrenade_projectile")
-    for __,hProjectile in ipairs(tThrewnNades) do
+    for __, hProjectile in ipairs(tThrewnNades) do
         if hProjectile and hProjectile:GetOwner() == hInfected then
             DoEntFireByInstanceHandle(hProjectile, "Kill", "", 0.02, nil, nil)
         end
@@ -76,14 +76,14 @@ function InfectMotherZombie(hInfected, bKeepPosition)
 
     -- Asynchronously kill any utils held by the infected player AND any nades threwn by said player
     local tHeldWeapons = hInfected:GetEquippedWeapons()
-    for _,hWeapon in ipairs(tHeldWeapons) do
+    for _, hWeapon in ipairs(tHeldWeapons) do
         if hWeapon and hWeapon:GetClassname() ~= "weapon_knife" then
             DoEntFireByInstanceHandle(hWeapon, "Kill", "", 0.02, nil, nil)
         end
     end
 
     local tThrewnNades = Entities:FindAllByClassname("hegrenade_projectile")
-    for __,hProjectile in ipairs(tThrewnNades) do
+    for __, hProjectile in ipairs(tThrewnNades) do
         if hProjectile and hProjectile:GetOwner() == hInfected then
             DoEntFireByInstanceHandle(hProjectile, "Kill", "", 0.02, nil, nil)
         end

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -31,6 +31,24 @@ function Infect(hInflictor, hInfected, bKeepPosition, bDead)
 
     hInfected:SetTeam(CS_TEAM_T)
 
+    -- Asynchronously kill any utils held by the infected player AND any nades threwn by said player
+    -- Issue: cooking a grenade and getting infected lets you hold that grenade
+    -- while being a zombie, which bypasses grenade-killing in the OnItemEquip
+    -- Issue 2: Cooking a grenade and getting infected causes you to drop the grenade, which then can damage humans
+    local tHeldWeapons = hInfected:GetEquippedWeapons()
+    for _,hWeapon in ipairs(tHeldWeapons) do
+        if hWeapon and hWeapon:GetClassname() ~= "weapon_knife" then
+            DoEntFireByInstanceHandle(hWeapon, "Kill", "", 0.02, nil, nil)
+        end
+    end
+    
+    local tThrewnNades = Entities:FindAllByClassname("hegrenade_projectile")
+    for __,hProjectile in ipairs(tThrewnNades) do
+        if hProjectile and hProjectile:GetOwner() == hInfected then
+            DoEntFireByInstanceHandle(hProjectile, "Kill", "", 0.02, nil, nil)
+        end
+    end
+
     DebugPrint("Setting regular zombie class")
     InjectPlayerClass(PickRandomZombieDefaultClass(), hInfected)
 
@@ -58,6 +76,21 @@ function InfectMotherZombie(hInfected, bKeepPosition)
     tMZList[hInfected] = true
     hInfected:SetTeam(CS_TEAM_NONE)
     hInfected:SetTeam(CS_TEAM_T)
+
+    -- Same thing as in Infect() @ tHeldWeapons
+    local tHeldWeapons = hInfected:GetEquippedWeapons()
+    for _,hWeapon in ipairs(tHeldWeapons) do
+        if hWeapon and hWeapon:GetClassname() ~= "weapon_knife" then
+            DoEntFireByInstanceHandle(hWeapon, "Kill", "", 0.02, nil, nil)
+        end
+    end
+
+    local tThrewnNades = Entities:FindAllByClassname("hegrenade_projectile")
+    for __,hProjectile in ipairs(tThrewnNades) do
+        if hProjectile and hProjectile:GetOwner() == hInfected then
+            DoEntFireByInstanceHandle(hProjectile, "Kill", "", 0.02, nil, nil)
+        end
+    end
 
     DebugPrint("Setting mother zombie class")
     InjectPlayerClass(ZRClass.Zombie.MotherZombie, hInfected)

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -38,7 +38,7 @@ function Infect(hInflictor, hInfected, bKeepPosition, bDead)
             DoEntFireByInstanceHandle(hWeapon, "Kill", "", 0.02, nil, nil)
         end
     end
-    
+
     local tThrewnNades = Entities:FindAllByClassname("hegrenade_projectile")
     for __,hProjectile in ipairs(tThrewnNades) do
         if hProjectile and hProjectile:GetOwner() == hInfected then

--- a/scripts/vscripts/ZombieReborn/Infect.lua
+++ b/scripts/vscripts/ZombieReborn/Infect.lua
@@ -32,9 +32,6 @@ function Infect(hInflictor, hInfected, bKeepPosition, bDead)
     hInfected:SetTeam(CS_TEAM_T)
 
     -- Asynchronously kill any utils held by the infected player AND any nades threwn by said player
-    -- Issue: cooking a grenade and getting infected lets you hold that grenade
-    -- while being a zombie, which bypasses grenade-killing in the OnItemEquip
-    -- Issue 2: Cooking a grenade and getting infected causes you to drop the grenade, which then can damage humans
     local tHeldWeapons = hInfected:GetEquippedWeapons()
     for _,hWeapon in ipairs(tHeldWeapons) do
         if hWeapon and hWeapon:GetClassname() ~= "weapon_knife" then
@@ -77,7 +74,7 @@ function InfectMotherZombie(hInfected, bKeepPosition)
     hInfected:SetTeam(CS_TEAM_NONE)
     hInfected:SetTeam(CS_TEAM_T)
 
-    -- Same thing as in Infect() @ tHeldWeapons
+    -- Asynchronously kill any utils held by the infected player AND any nades threwn by said player
     local tHeldWeapons = hInfected:GetEquippedWeapons()
     for _,hWeapon in ipairs(tHeldWeapons) do
         if hWeapon and hWeapon:GetClassname() ~= "weapon_knife" then


### PR DESCRIPTION
PR fixes issues which popped up during tests:
- There's no weapon type check happening before/during infection, meaning that if zombies
could somehow damage humans with other means than a knife, that damage would infect humans
- When you get infected while cooking a grenade, you continue to hold that grenade after re-spawning as a zombie,
which bypasses the utility killing inside OnItemEquip and lets zombies throw a grenade
- When you get infected while cooking a grenade, you drop that grenade, which then will hurt humans as the owner of the grenade is now a zombie